### PR TITLE
housekeeping: install android-30

### DIFF
--- a/.github/workflows/workflow-common-release.yml
+++ b/.github/workflows/workflow-common-release.yml
@@ -91,6 +91,19 @@ jobs:
         distribution: 'microsoft'
         java-version: '11'
         
+    - name: Setup Android SDK
+      uses: android-actions/setup-android@v3
+
+    - name: Install Android SDK
+      run: |
+        $sdkmanagerpath = Get-ChildItem "C:\Android\android-sdk\cmdline-tools\**\bin\sdkmanager.bat" | Select-Object -First 1
+        if ($sdkmanagerpath -eq $null) {
+            throw "Unable to find android sdk manager"
+        }
+
+        echo $sdkmanagerpath
+        . $sdkmanagerpath --install "platforms;android-30"
+
     - name: Checkout
       uses: actions/checkout@v4
       with:


### PR DESCRIPTION
<!-- Please be sure to read the [Contribute](https://github.com/reactiveui/reactiveui#contribute) section of the README -->

**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->

https://github.com/actions/runner-images/issues/8952 has removed android-30 so the CI builds are all about to fail


**What is the current behavior?**
<!-- You can also link to an open issue here. -->

builds fail

**What is the new behavior?**
<!-- If this is a feature change -->

installs commandline tools, then installs android-30

**What might this PR break?**



**Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

