### PR TITLE
fix(sonarcloud): stop Git Bash mangling scanner switches on Windows

### DIFF
--- a/.github/actions/sonarcloud/action.yml
+++ b/.github/actions/sonarcloud/action.yml
@@ -89,6 +89,13 @@ runs:
       if: inputs.mode == 'begin'
       shell: bash
       working-directory: ${{ inputs.working-directory }}
+      env:
+        # On Windows runners this step executes under Git Bash (MSYS2), which
+        # rewrites arguments that look like Unix paths — turning the scanner's
+        # /k:, /o:, /d: and /v: switches into k:, o:, ... and breaking the
+        # invocation. Excluding every argument from path conversion passes them
+        # through verbatim; harmless on Linux/macOS where no conversion happens.
+        MSYS2_ARG_CONV_EXCL: '*'
       run: |
         VERSION_ARG=""
         if [ -n "${{ inputs.version }}" ]; then
@@ -134,4 +141,8 @@ runs:
       if: inputs.mode == 'end'
       shell: bash
       working-directory: ${{ inputs.working-directory }}
+      env:
+        # See the begin step: stop Git Bash (MSYS2) on Windows from rewriting the
+        # /d:sonar.token switch (and the // in any URL value) before the scanner sees it.
+        MSYS2_ARG_CONV_EXCL: '*'
       run: dotnet sonarscanner end /d:sonar.token="$SONAR_TOKEN"


### PR DESCRIPTION
## Problem

When the SonarCloud scan runs on a **Windows** runner, the `begin`/`end` steps execute under **Git Bash (MSYS2)**, which rewrites arguments that look like Unix paths. The scanner's `/k:`, `/o:`, `/d:` and `/v:` switches become `k:`, `o:`, … so `dotnet-sonarscanner` fails pre-processing with:

```
Unrecognized command line argument: k:reactiveui_splat
A required argument is missing: /key:[SonarQube/SonarCloud project key]
Pre-processing failed. Exit code: 1
```

## Fix

Set `MSYS2_ARG_CONV_EXCL='*'` on the `begin` and `end` steps so Git Bash passes the switches through verbatim. It's a no-op on Linux/macOS where no path conversion happens.

Single file: `.github/actions/sonarcloud/action.yml`.